### PR TITLE
Fix brightness scaling

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -101,7 +101,8 @@
 #endif
 
 static MatrixPanel_I2S_DMA *_matrix;
-static int _brightness = -1;
+static uint8_t _brightness = DISPLAY_DEFAULT_BRIGHTNESS;
+static const char *TAG = "display";
 
 int display_initialize() {
   // Initialize the panel.
@@ -143,13 +144,22 @@ int display_initialize() {
   return 0;
 }
 
-void display_set_brightness(int b) {
-  if (b != _brightness) {
-    _brightness = b;
-    _matrix->setBrightness8(b);
+static inline uint8_t brightness_percent_to_8bit(uint8_t pct) {
+  if (pct > 100) pct = 100;
+  return (uint8_t)(((uint32_t)pct * 255 + 50) / 100);
+}
+
+void display_set_brightness(uint8_t brightness_pct) {
+  if (brightness_pct != _brightness) {
+    uint8_t brightness_8bit = brightness_percent_to_8bit(brightness_pct);
+    ESP_LOGI(TAG, "Setting brightness to %d%% (%d)", brightness_pct, brightness_8bit);
+    _matrix->setBrightness8(brightness_8bit);
     _matrix->clearScreen();
+    _brightness = brightness_pct;
   }
 }
+
+uint8_t display_get_brightness() { return _brightness; }
 
 void display_shutdown() {
   _matrix->clearScreen();

--- a/src/display.h
+++ b/src/display.h
@@ -11,7 +11,8 @@ extern int32_t isAnimating;  // Declare the variable
 extern "C" {
 #endif
 int display_initialize();
-void display_set_brightness(int b);
+void display_set_brightness(uint8_t brightness_pct);
+uint8_t display_get_brightness();
 void display_shutdown();
 
 void display_draw(const uint8_t *pix, int width, int height, int channels,

--- a/src/main.c
+++ b/src/main.c
@@ -55,18 +55,15 @@ void app_main(void) {
   for (;;) {
     uint8_t* webp;
     size_t len;
-    static int32_t brightness = DISPLAY_DEFAULT_BRIGHTNESS;
+    static uint8_t brightness_pct = DISPLAY_DEFAULT_BRIGHTNESS;
 
-    if (remote_get(TIDBYT_REMOTE_URL, &webp, &len, &brightness,
+    if (remote_get(TIDBYT_REMOTE_URL, &webp, &len, &brightness_pct,
                    &app_dwell_secs)) {
       ESP_LOGE(TAG, "Failed to get webp");
       vTaskDelay(pdMS_TO_TICKS(1 * 1000));
     } else {
       // Successful remote_get
-      if (brightness > -1 && brightness < 256) {
-        ESP_LOGI(TAG, BLUE "setting brightness to %d" RESET, (int)brightness);
-        display_set_brightness(brightness);
-      }
+      display_set_brightness(brightness_pct);
       ESP_LOGI(TAG, BLUE "Queuing new webp (%d bytes)" RESET, len);
       gfx_update(webp, len);
       free(webp);

--- a/src/remote.h
+++ b/src/remote.h
@@ -4,4 +4,4 @@
 
 // Retrieves url via HTTP GET. Caller is responsible for freeing buf
 // on success.
-int remote_get(const char* url, uint8_t** buf, size_t* len, int32_t* brightness, int32_t* dwell_secs);
+int remote_get(const char* url, uint8_t** buf, size_t* len, uint8_t* brightness_pct, int32_t* dwell_secs);


### PR DESCRIPTION
Previously we passed 0-100 from the API directly to [`setBrightness8()`](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/blob/4c7585debe783c05eee0b671b93dda021ec3e289/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h#L670-L679), capping brightness at ~40% of the expected 0-255 range. 

See https://github.com/tronbyt/server/issues/225